### PR TITLE
Fix post field naming

### DIFF
--- a/database/migrations/2025_05_14_160724_create_posts_table.php
+++ b/database/migrations/2025_05_14_160724_create_posts_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('title');
             $table->text('content');
             $table->unsignedBigInteger('category_id')->nullable();
             $table->timestamps();

--- a/resources/views/admin/post/create.blade.php
+++ b/resources/views/admin/post/create.blade.php
@@ -30,8 +30,8 @@
                     <form action="{{ route('admin.post.store') }}" method="post" enctype="multipart/form-data">
                         @csrf
                         <div class="form-group w-25">
-                            <input type="text" class="form-control" name="name" placeholder="Название поста" value="{{ old('name') }}">
-                            @error('name')
+                            <input type="text" class="form-control" name="title" placeholder="Название поста" value="{{ old('title') }}">
+                            @error('title')
                                 <div class="text-danger"> {{ $message }} </div>
                             @enderror
                         </div>

--- a/resources/views/admin/post/edit.blade.php
+++ b/resources/views/admin/post/edit.blade.php
@@ -31,8 +31,8 @@
                         @csrf
                         @method('patch')
                         <div class="form-group 25">
-                            <input type="text" class="form-control" name="name" placeholder="Название поста" value="{{ $post->name }}">
-                            @error('name')
+                            <input type="text" class="form-control" name="title" placeholder="Название поста" value="{{ $post->title }}">
+                            @error('title')
                                 <div class="text-danger"> {{ $message }} </div>
                             @enderror
                         </div>

--- a/resources/views/admin/post/index.blade.php
+++ b/resources/views/admin/post/index.blade.php
@@ -46,7 +46,7 @@
                                 @foreach ($posts as $post)
                                     <tr>
                                         <td>{{ $post->id }}</td>
-                                        <td>{{ $post->name }}</td>
+                                        <td>{{ $post->title }}</td>
                                         <td>
                                             <a href="{{ route('admin.post.show', $post->id) }}">
                                                 <i class="fa fa-eye"></i>

--- a/resources/views/admin/post/show.blade.php
+++ b/resources/views/admin/post/show.blade.php
@@ -8,7 +8,7 @@
         <div class="container-fluid">
             <div class="row mb-2">
                 <div class="col-sm-6 d-flex align-items-center">
-                    <h1 class="m-0 mr-2">{{ $post->name }}</h1>
+                    <h1 class="m-0 mr-2">{{ $post->title }}</h1>
                     <a href="{{ route('admin.post.edit', $post->id) }}" class="text-success">
                         <i class="fa fa-pencil-alt"></i>
                     </a>
@@ -45,7 +45,7 @@
                                 </tr>
                                 <tr>
                                     <td>Название</td>
-                                    <td>{{ $post->name }}</td>
+                                    <td>{{ $post->title }}</td>
                                 </tr>
                             </table>
                         </div>


### PR DESCRIPTION
## Summary
- rename post name to title everywhere
- update create/edit forms and views
- adjust posts migration to use title

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684422b99c84833284aea7fffe802aac