### PR TITLE
Fix post field revert

### DIFF
--- a/app/Http/Requests/Admin/Post/StoreRequest.php
+++ b/app/Http/Requests/Admin/Post/StoreRequest.php
@@ -24,7 +24,7 @@ class StoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required|string',
+            'name' => 'required|string',
             'content' => 'required|string',
             'preview_image' => 'required|image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',
             'main_image' => 'required|image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',

--- a/app/Http/Requests/Admin/Post/UpdateRequest.php
+++ b/app/Http/Requests/Admin/Post/UpdateRequest.php
@@ -24,7 +24,7 @@ class UpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required|string',
+            'name' => 'required|string',
             'content' => 'required|string',
             'preview_image' => 'required|image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',
             'main_image' => 'required|image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',

--- a/app/Http/Requests/Admin/Tag/StoreRequest.php
+++ b/app/Http/Requests/Admin/Tag/StoreRequest.php
@@ -24,7 +24,7 @@ class StoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
+            'title' => 'required|string',
         ];
     }
 }

--- a/app/Http/Requests/Admin/Tag/UpdateRequest.php
+++ b/app/Http/Requests/Admin/Tag/UpdateRequest.php
@@ -24,7 +24,7 @@ class UpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
+            'title' => 'required|string',
         ];
     }
 }

--- a/database/migrations/2025_05_14_161021_create_tags_table.php
+++ b/database/migrations/2025_05_14_161021_create_tags_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('tags', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('title');
             $table->timestamps();
         });
     }

--- a/resources/views/admin/tag/create.blade.php
+++ b/resources/views/admin/tag/create.blade.php
@@ -30,8 +30,8 @@
                     <form action="{{ route('admin.tag.store') }}" method="post" class="w-25">
                         @csrf
                         <div class="form-group">
-                            <input type="text" class="form-control" name="name" placeholder="Название тега">
-                            @error('name')
+                            <input type="text" class="form-control" name="title" placeholder="Название тега">
+                            @error('title')
                                 <div class="text-danger"> {{ $message }} </div>
                             @enderror
                         </div>

--- a/resources/views/admin/tag/edit.blade.php
+++ b/resources/views/admin/tag/edit.blade.php
@@ -31,8 +31,8 @@
                         @csrf
                         @method('patch')
                         <div class="form-group">
-                            <input type="text" class="form-control" name="name" placeholder="Название тега" value="{{ $tag->name }}">
-                            @error('name')
+                            <input type="text" class="form-control" name="title" placeholder="Название тега" value="{{ $tag->title }}">
+                            @error('title')
                                 <div class="text-danger"> {{ $message }} </div>
                             @enderror
                         </div>

--- a/resources/views/admin/tag/index.blade.php
+++ b/resources/views/admin/tag/index.blade.php
@@ -46,7 +46,7 @@
                                 @foreach ($tags as $tag)
                                     <tr>
                                         <td>{{ $tag->id }}</td>
-                                        <td>{{ $tag->name }}</td>
+                                        <td>{{ $tag->title }}</td>
                                         <td>
                                             <a href="{{ route('admin.tag.show', $tag->id) }}">
                                                 <i class="fa fa-eye"></i>

--- a/resources/views/admin/tag/show.blade.php
+++ b/resources/views/admin/tag/show.blade.php
@@ -8,7 +8,7 @@
         <div class="container-fluid">
             <div class="row mb-2">
                 <div class="col-sm-6 d-flex align-items-center">
-                    <h1 class="m-0 mr-2">{{ $tag->name }}</h1>
+                    <h1 class="m-0 mr-2">{{ $tag->title }}</h1>
                     <a href="{{ route('admin.tag.edit', $tag->id) }}" class="text-success">
                         <i class="fa fa-pencil-alt"></i>
                     </a>
@@ -45,7 +45,7 @@
                                     </tr>
                                 <tr>
                                     <td>Название</td>
-                                    <td>{{ $tag->name }}</td>
+                                    <td>{{ $tag->title }}</td>
                                 </tr>
                             </table>
                         </div>


### PR DESCRIPTION
## Summary
- revert posts to use `name` field while keeping tag titles

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684422b99c84833284aea7fffe802aac